### PR TITLE
Issue #6: Setting "Collapse all tabs by default" has a wrong description

### DIFF
--- a/ckeditor_accordion.module
+++ b/ckeditor_accordion.module
@@ -73,7 +73,6 @@ function ckeditor_accordion_admin() {
     '#type' => 'checkbox',
     '#title' => t('Collapse all tabs by default'),
     '#default_value' => config_get('ckeditor_accordion.settings', 'ckeditor_accordion_collapsed'),
-    '#description' => t("The maximum number of links to display in the block."),
   );
 
   return system_settings_form($form);


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ckeditor_accordion/issues/6.